### PR TITLE
Update docs to reflect addition of 'assert' to chai-karma-snapshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,14 +130,17 @@ Test file:
 
 ```js
 // __tests__/index.js
-import { use, expect } from "chai";
+import { use, expect, assert } from "chai";
 import { matchSnapshot } from "chai-karma-snapshot";
 import { test } from "../src/index.js";
 use(matchSnapshot);
 
 describe("src/index.js", () => {
   it("check snapshot", () => {
+    // 'expect' syntax
     expect(test()).to.matchSnapshot();
+    // 'assert' syntax
+    assert.matchSnapshot(test());
   });
 });
 ```


### PR DESCRIPTION
This is a sidekick to https://github.com/localvoid/chai-karma-snapshot/pull/4 (explanation there:
>I noticed I didn't seem to be able to use the assert syntax so I made some changes that expand the functionality of the library. 

)

That PR should be merged first, otherwise this will make the docs lie! ^^