### PR TITLE
Allow to limit unused snapshots being reported

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,10 @@ config.set({
     prune: false,           // Prune unused snapshots (default: false)
     format: "indented-md",  // Snapshot format (default: md)
     checkSourceFile: true,  // Checks existince of the source file associated with tests (default: false)
-    pathResolver: resolve,  // Custom path resolver
+    pathResolver: resolve,  // Custom path resolver,
+    limitUnusedSnapshotsInWarning: -1  // Limit number of unused snapshots reported in the warning
+                                       // -1 means no limit
+
   }
 });
 ```

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,41 @@ function defaultPathResolver(basePath, suiteName) {
   return path.join(suiteSourceDir, "__snapshots__", sourceFileName + ".md");
 }
 
+/**
+ * Renders a list of snapshots up to specified limit of lines
+ * @param list {array} list of snapshots
+ * @param limit {number} maximum number of lines rendered under summary
+ * @returns {string}
+ */
+function formatSnapshotList(list, limit) {
+  limit = (typeof limit != 'undefined') ? limit : -1;
+
+  const limitedList = limit > 0 ? list.slice(0, limit) : list;
+  const hasMore = list.length > limitedList.length;
+  const buildList = (snapshots) => snapshots.map((s) => s.join(' > ')).join('\n');
+
+  if (hasMore) {
+    return buildList(limitedList.slice(0, -1)) + `\n +${list.length - limitedList.length + 1} more`;
+  }
+
+  return buildList(limitedList);
+}
+
+/**
+ * Renders the message for unused snapshots warning
+ * @param list {array} list of snapshots
+ * @param limit {number} maximum number of lines rendered under summary
+ * @returns {string}
+ */
+function formatUnusedSnapshotsWarning(list, limit) {
+  if (limit == 0) {
+    return `Found ${list.length} unused snapshots`;
+  }
+
+  const prunedList = formatSnapshotList(list, limit);
+  return `Found ${list.length} unused snapshots:\n${prunedList}`;
+}
+
 let snapshotSerializer;
 
 /**
@@ -52,7 +87,8 @@ function snapshotFramework(files, config, emitter, loggerFactory) {
     prune: false,
     format: "md",
     checkSourceFile: false,
-    pathResolver: defaultPathResolver
+    pathResolver: defaultPathResolver,
+    limitUnusedSnapshotsInWarning: -1
   }, config.snapshot);
 
   if (typeof snapshotConfig.format === "string") {
@@ -88,14 +124,14 @@ function snapshotFramework(files, config, emitter, loggerFactory) {
         if (!lastResult.error && lastResult.failed === 0 && lastResult.skipped === 0) {
           const prunedSnapshots = prune.pruneSnapshots(rootSuite);
           if (prunedSnapshots.pruned.length > 0) {
-            const prunedList = prunedSnapshots.pruned.map((s) => s.join(' > ')).join('\n');
             if (snapshotConfig.prune) {
+              const prunedList = formatSnapshotList(prunedSnapshots.pruned)
               logger.warn(`Removed ${prunedSnapshots.pruned.length} unused snapshots:\n${prunedList}`);
               rootSuite = prunedSnapshots.suite;
               prune.pruneFiles(snapshotConfig.pathResolver, config.basePath, prunedSnapshots.prunedFiles);
               dirty = true;
             } else {
-              logger.warn(`Found ${prunedSnapshots.pruned.length} unused snapshots:\n${prunedList}`);
+              logger.warn(formatUnusedSnapshotsWarning(prunedSnapshots.pruned, snapshotConfig.limitUnusedSnapshotsInWarning));
             }
           }
         }


### PR DESCRIPTION
aims to address #3 

Add `limitUnusedSnapshotsInWarning` configuration option to limit the number of snapshots reported in the warning. The default value is -1 and it matches the current behavior of no limit at all.

When a number of snapshots is bigger than the limit, we display LIMIT - 1 snapshots plus an extra line with `+ N more` to render exactly the same number of lines.